### PR TITLE
Pin exceptions

### DIFF
--- a/lib/point/core/post.py
+++ b/lib/point/core/post.py
@@ -36,13 +36,18 @@ class PostDiffError(PostError):
 class PostCommentedError(PostError):
     pass
 
-
 class PostReadonlyError(PostError):
     pass
 
-
 class PostLimitError(PostError):
     pass
+
+class PostAlreadyPinnedError(PostError):
+    pass
+
+class PostNotPinnedError(PostError):
+    pass
+
 
 class Post(object):
     def __init__(self, post_id, author=None, type=None, tags=None,


### PR DESCRIPTION
Новые исключения для XMPP:

* `PostAlreadyPinnedError` - возбуждается, если пользователь пытается закрепить уже закреплённый пост
* `PostNotPinnedError` - возбуждается, если полызователь пытается снять закрепление поста, который не закреплён